### PR TITLE
Update CommunityToolkit and DevWinUI package versions

### DIFF
--- a/src/CCEM/CCEM.csproj
+++ b/src/CCEM/CCEM.csproj
@@ -62,12 +62,12 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
-    <PackageReference Include="CommunityToolkit.WinUI.Animations" Version="8.2.250402" />
-    <PackageReference Include="CommunityToolkit.WinUI.Controls.SettingsControls" Version="8.2.250402" />
-    <PackageReference Include="DevWinUI" Version="9.5.0" />
+    <PackageReference Include="CommunityToolkit.WinUI.Animations" Version="8.2.251219" />
+    <PackageReference Include="CommunityToolkit.WinUI.Controls.SettingsControls" Version="8.2.251219" />
+    <PackageReference Include="DevWinUI" Version="9.8.1" />
     <PackageReference Include="DevWinUI.ContextMenu" Version="9.5.0" />
-    <PackageReference Include="DevWinUI.Controls" Version="9.5.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
+    <PackageReference Include="DevWinUI.Controls" Version="9.8.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.1" />
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.7175" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.251106002" />


### PR DESCRIPTION
This pull request updates several NuGet package dependencies in the `src/CCEM/CCEM.csproj` file to newer versions. These updates ensure that the project uses the latest features and bug fixes from these libraries.

Dependency version upgrades:

* Upgraded `CommunityToolkit.WinUI.Animations` and `CommunityToolkit.WinUI.Controls.SettingsControls` from version `8.2.250402` to `8.2.251219`.
* Upgraded `DevWinUI` and `DevWinUI.Controls` from version `9.5.0` to `9.8.1`.
* Upgraded `Microsoft.Extensions.DependencyInjection` from version `10.0.0` to `10.0.1`.