### PR TITLE
Updates the copyright year in the `LICENSE` file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Mickaël CHAVE
+Copyright (c) 2025-2026 Mickaël CHAVE
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This pull request updates the copyright year in the `LICENSE` file to include 2025.

- Legal/Documentation update:
  * Updated the copyright notice in `LICENSE` to reflect the years 2025-2026.