### PR TITLE
Refactors tag matching

### DIFF
--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -87,13 +87,16 @@ jobs:
           function Get-LatestStableTag([string[]]$allTags, [string]$excludeTag, [int]$maxYY, [int]$maxMM) {
             $stableTags =
               $allTags |
-              Where-Object { $_ -match $stablePattern -and $_ -ne $excludeTag } |
               ForEach-Object {
+                if ($_ -eq $excludeTag) { return }
+                $m = [regex]::Match($_, $stablePattern)
+                if (-not $m.Success) { return }
+
                 [pscustomobject]@{
                   Tag   = $_
-                  YY    = [int]$Matches[1]
-                  MM    = [int]$Matches[2]
-                  Patch = [int]$Matches[3]
+                  YY    = [int]$m.Groups[1].Value
+                  MM    = [int]$m.Groups[2].Value
+                  Patch = [int]$m.Groups[3].Value
                 }
               }
 
@@ -118,9 +121,11 @@ jobs:
             $sameLineBetaPattern = "^v$yy\\.$mm\\.0-beta\\.(\\d+)$"
             $previousBuild =
               $allTags |
-              Where-Object { $_ -match $sameLineBetaPattern } |
-              ForEach-Object { [int]$Matches[1] } |
-              Where-Object { $_ -lt $build } |
+              ForEach-Object {
+                $m = [regex]::Match($_, $sameLineBetaPattern)
+                if ($m.Success) { [int]$m.Groups[1].Value } else { $null }
+              } |
+              Where-Object { $null -ne $_ -and $_ -lt $build } |
               Sort-Object -Descending |
               Select-Object -First 1
 
@@ -138,9 +143,11 @@ jobs:
             $sameLineStablePattern = "^v$yy\\.$mm\\.(\\d+)$"
             $previousPatch =
               $allTags |
-              Where-Object { $_ -match $sameLineStablePattern } |
-              ForEach-Object { [int]$Matches[1] } |
-              Where-Object { $_ -lt $patch } |
+              ForEach-Object {
+                $m = [regex]::Match($_, $sameLineStablePattern)
+                if ($m.Success) { [int]$m.Groups[1].Value } else { $null }
+              } |
+              Where-Object { $null -ne $_ -and $_ -lt $patch } |
               Sort-Object -Descending |
               Select-Object -First 1
 

--- a/.gitignore
+++ b/.gitignore
@@ -416,6 +416,3 @@ FodyWeavers.xsd
 *.msix
 *.msm
 *.msp
-
-# UnigetUI source files
-Example_UnigetUI/

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025-2026 Mickaël CHAVE
+Copyright (c) 2026 Mickaël CHAVE
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This pull request primarily refactors how tag matching and extraction are performed in the PowerShell scripts within the GitHub release workflow. The changes improve reliability by switching from implicit regex matching to explicit regex extraction, ensuring that tag components are parsed correctly. Additionally, there is a minor update to the copyright years in the `LICENSE` file.

### Workflow improvements

* Refactored the tag filtering and extraction logic in the `Get-LatestStableTag` function to use explicit regex matching and extraction via `[regex]::Match`, replacing reliance on `$Matches` and implicit matching. This makes the code more robust and easier to understand.
* Updated the logic for finding previous beta and stable builds to use `[regex]::Match` for extracting build/patch numbers, ensuring that only valid matches are processed and preventing potential errors from unmatched patterns. [[1]](diffhunk://#diff-2832baa5db895caf7dfeb7dfa640f20ce8436091774f018ea55f3aea1f0d562bL121-R128) [[2]](diffhunk://#diff-2832baa5db895caf7dfeb7dfa640f20ce8436091774f018ea55f3aea1f0d562bL141-R150)

### License update

* Updated the copyright years in the `LICENSE` file to reflect only 2026, removing the previous range.