### PR TITLE
Bump version 26.1.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -416,6 +416,3 @@ FodyWeavers.xsd
 *.msix
 *.msm
 *.msp
-
-# UnigetUI source files
-Example_UnigetUI/

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025-2026 Mickaël CHAVE
+Copyright (c) 2026 Mickaël CHAVE
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This pull request makes a minor update to the copyright years in the `LICENSE` file. The change ensures the license reflects the correct year range for copyright ownership.