### PR TITLE
feat: update DevWinUI package references to version 9.9.1

### DIFF
--- a/src/CCEM/CCEM.csproj
+++ b/src/CCEM/CCEM.csproj
@@ -64,9 +64,9 @@
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageReference Include="CommunityToolkit.WinUI.Animations" Version="8.2.251219" />
     <PackageReference Include="CommunityToolkit.WinUI.Controls.SettingsControls" Version="8.2.251219" />
-    <PackageReference Include="DevWinUI" Version="9.8.1" />
-    <PackageReference Include="DevWinUI.ContextMenu" Version="9.5.0" />
-    <PackageReference Include="DevWinUI.Controls" Version="9.8.1" />
+    <PackageReference Include="DevWinUI" Version="9.9.1" />
+    <PackageReference Include="DevWinUI.ContextMenu" Version="9.9.0" />
+    <PackageReference Include="DevWinUI.Controls" Version="9.9.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.1" />
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.7175" />


### PR DESCRIPTION
This pull request updates the `DevWinUI` package dependencies in the project to newer versions. This ensures compatibility with the latest features and bug fixes from the DevWinUI library.

Dependency updates:

* Upgraded `DevWinUI` from version 9.8.1 to 9.9.1 in `CCEM.csproj`.
* Upgraded `DevWinUI.ContextMenu` from version 9.5.0 to 9.9.0 in `CCEM.csproj`.
* Upgraded `DevWinUI.Controls` from version 9.8.1 to 9.9.1 in `CCEM.csproj`.